### PR TITLE
chore: release note 자동화 workflow 추가

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,42 @@
+name-template: '🚀 v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '✨ Features'
+    labels:
+      - 'feature'
+      - 'feature ✨'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'fix 🐛'
+  - title: '🧰 Maintenance'
+    label:
+      - 'chore'
+      - 'docs'
+      - 'chore 🔨'
+      - 'docs 📝'
+  - title: '⚡ performance'
+    label:
+      - 'refactor'
+      - 'test'
+      - 'refactor ♻️'
+      - 'test ✅'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  template: |
+  ## 📌 변경 사항
+  ---
+  $CHANGES
+no-changes-template: '⚠️ 변경 사항이 없어요!'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-config.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 참고
- [GitHub actions example for automatic release drafts and changelog.md creation](https://johanneskonings.dev/github/2021/02/28/github_automatic_releases_and-changelog/)
- [release-drafter](https://github.com/marketplace/actions/release-drafter)