### PR TITLE
feat: PDF 이력서 다운로드 기능 구현

### DIFF
--- a/src/app/(editor)/activity/page.tsx
+++ b/src/app/(editor)/activity/page.tsx
@@ -3,7 +3,7 @@
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { v4 } from 'uuid';
 
-import { Input } from '@/components/common';
+import { Button, Input } from '@/components/common';
 import { FormCard, MarkdownInput, PeriodInput } from '@/components/Form';
 import FormRemoveButton from '@/components/Form/FormRemoveButton';
 import { INITIAL_VALUE, PLACEHOLDER } from '@/constants/form';
@@ -56,48 +56,58 @@ const Page = () => {
       title={MENU_INFO.ACTIVITY.TITLE}
       guide={MENU_INFO.ACTIVITY.GUIDE}
       onAppendForm={handleAppendClick}
-      onSaveForm={handleSaveClick}
     >
-      <ul>
-        {fields.map((item, index) => (
-          <li key={item.id} className="border-b border-gray-200/70 py-6">
-            <div className="mb-3 flex items-end gap-2">
-              <Input
-                {...register(`activities.${index}.title`)}
-                id="title"
-                className="mr-1"
-                label={{ text: '수상 및 활동명', isRequired: true }}
-                placeholder={PLACEHOLDER.ACTIVITY.TITLE}
-                error={errors.activities?.[index]?.title?.message}
-                autoFocus
-              />
-              <FormRemoveButton onRemoveForm={() => handleRemoveClick(index)} />
-            </div>
-            <Input
-              {...register(`activities.${index}.institution`)}
-              id="title"
-              className="mb-3"
-              label={{ text: '기관명', isRequired: true }}
-              placeholder={PLACEHOLDER.ACTIVITY.INSTITUTION}
-            />
-            <PeriodInput
-              formName="activities"
-              index={index}
-              error={{
-                startDate: errors.activities?.[index]?.startDate?.message,
-                endDate: errors.activities?.[index]?.endDate?.message,
-              }}
-            />
-            <MarkdownInput
-              formName="activities"
-              index={index}
-              label="내용"
-              placeholder={PLACEHOLDER.ACTIVITY.CONTENT}
-              error={errors.activities?.[index]?.content?.message}
-            />
-          </li>
-        ))}
-      </ul>
+      {fields.length > 0 && (
+        <div className="mt-5">
+          <ul>
+            {fields.map((item, index) => (
+              <li key={item.id} className="border-b border-gray-200/70 py-6">
+                <div className="mb-3 flex items-end gap-2">
+                  <Input
+                    {...register(`activities.${index}.title`)}
+                    id="title"
+                    className="mr-1"
+                    label={{ text: '수상 및 활동명', isRequired: true }}
+                    placeholder={PLACEHOLDER.ACTIVITY.TITLE}
+                    error={errors.activities?.[index]?.title?.message}
+                    autoFocus
+                  />
+                  <FormRemoveButton
+                    onRemoveForm={() => handleRemoveClick(index)}
+                  />
+                </div>
+                <Input
+                  {...register(`activities.${index}.institution`)}
+                  id="title"
+                  className="mb-3"
+                  label={{ text: '기관명', isRequired: true }}
+                  placeholder={PLACEHOLDER.ACTIVITY.INSTITUTION}
+                />
+                <PeriodInput
+                  formName="activities"
+                  index={index}
+                  error={{
+                    startDate: errors.activities?.[index]?.startDate?.message,
+                    endDate: errors.activities?.[index]?.endDate?.message,
+                  }}
+                />
+                <MarkdownInput
+                  formName="activities"
+                  index={index}
+                  label="내용"
+                  placeholder={PLACEHOLDER.ACTIVITY.CONTENT}
+                  error={errors.activities?.[index]?.content?.message}
+                />
+              </li>
+            ))}
+          </ul>
+          <div className="ml-auto mt-4 w-fit">
+            <Button type="button" onClick={handleSaveClick}>
+              저장
+            </Button>
+          </div>
+        </div>
+      )}
     </FormCard>
   );
 };

--- a/src/app/(editor)/activity/page.tsx
+++ b/src/app/(editor)/activity/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { v4 } from 'uuid';
 
@@ -10,9 +9,7 @@ import FormRemoveButton from '@/components/Form/FormRemoveButton';
 import { INITIAL_VALUE, PLACEHOLDER } from '@/constants/form';
 import { MENU_INFO } from '@/constants/menu';
 import { type ActivitiesFormDataSchema } from '@/types/form';
-import { storage, STORAGE_KEY } from '@/utils/storage';
-
-const webStorage = storage(STORAGE_KEY.ACTIVITY);
+import { storage } from '@/utils/storage';
 
 const Page = () => {
   const {
@@ -20,7 +17,6 @@ const Page = () => {
     register,
     trigger,
     getValues,
-    setValue,
     formState: { errors, dirtyFields },
   } = useFormContext<ActivitiesFormDataSchema>();
 
@@ -28,15 +24,6 @@ const Page = () => {
     name: 'activities',
     control,
   });
-
-  useEffect(() => {
-    const storageData = webStorage.get();
-
-    setValue(
-      'activities',
-      storageData ? storageData : [INITIAL_VALUE.ACTIVITY]
-    );
-  }, [setValue]);
 
   const handleAppendClick = () => {
     append({
@@ -50,7 +37,10 @@ const Page = () => {
 
     const formValues = getValues('activities');
 
-    webStorage.set(formValues.length ? formValues : [INITIAL_VALUE.ACTIVITY]);
+    storage.set({
+      ...storage.get(),
+      activities: formValues,
+    });
   };
 
   const handleSaveClick = () => {
@@ -62,7 +52,7 @@ const Page = () => {
       return;
     }
 
-    webStorage.set(formValues);
+    storage.set({ ...storage.get(), activities: formValues });
   };
 
   return (

--- a/src/app/(editor)/activity/page.tsx
+++ b/src/app/(editor)/activity/page.tsx
@@ -78,9 +78,9 @@ const Page = () => {
                 </div>
                 <Input
                   {...register(`activities.${index}.institution`)}
-                  id="title"
+                  id="institution"
                   className="mb-3"
-                  label={{ text: '기관명', isRequired: true }}
+                  label={{ text: '기관명' }}
                   placeholder={PLACEHOLDER.ACTIVITY.INSTITUTION}
                 />
                 <PeriodInput

--- a/src/app/(editor)/activity/page.tsx
+++ b/src/app/(editor)/activity/page.tsx
@@ -17,7 +17,7 @@ const Page = () => {
     register,
     trigger,
     getValues,
-    formState: { errors, dirtyFields },
+    formState: { errors },
   } = useFormContext<ActivitiesFormDataSchema>();
 
   const { fields, append, remove } = useFieldArray({
@@ -35,24 +35,20 @@ const Page = () => {
   const handleRemoveClick = (index: number) => {
     remove(index);
 
-    const formValues = getValues('activities');
-
     storage.set({
       ...storage.get(),
-      activities: formValues,
+      activities: getValues('activities'),
     });
   };
 
   const handleSaveClick = () => {
     trigger('activities');
 
-    const formValues = getValues('activities');
-
-    if (!dirtyFields.activities || errors.activities || !formValues.length) {
+    if (errors.activities) {
       return;
     }
 
-    storage.set({ ...storage.get(), activities: formValues });
+    storage.set({ ...storage.get(), activities: getValues('activities') });
   };
 
   return (

--- a/src/app/(editor)/basic/page.tsx
+++ b/src/app/(editor)/basic/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { Input, Label, Textarea } from '@/components/common';
@@ -8,22 +7,15 @@ import { FormCard } from '@/components/Form';
 import { PLACEHOLDER } from '@/constants/form';
 import { MENU_INFO } from '@/constants/menu';
 import { type UserInfoFormDataSchema } from '@/types/form';
-import { storage, STORAGE_KEY } from '@/utils/storage';
-
-const webStorage = storage(STORAGE_KEY.USER_INFO);
+import { storage } from '@/utils/storage';
 
 const Page = () => {
   const {
     register,
     trigger,
     getValues,
-    setValue,
     formState: { errors },
   } = useFormContext<UserInfoFormDataSchema>();
-
-  useEffect(() => {
-    setValue('userInfo', webStorage.get());
-  }, [setValue]);
 
   const handleSaveClick = () => {
     trigger('userInfo');
@@ -40,7 +32,7 @@ const Page = () => {
       return;
     }
 
-    webStorage.set(formValues);
+    storage.set({ ...storage.get(), userInfo: formValues });
   };
 
   return (

--- a/src/app/(editor)/basic/page.tsx
+++ b/src/app/(editor)/basic/page.tsx
@@ -2,7 +2,7 @@
 
 import { useFormContext } from 'react-hook-form';
 
-import { Input, Label, Textarea } from '@/components/common';
+import { Button, Input, Label, Textarea } from '@/components/common';
 import { FormCard } from '@/components/Form';
 import { PLACEHOLDER } from '@/constants/form';
 import { MENU_INFO } from '@/constants/menu';
@@ -28,67 +28,70 @@ const Page = () => {
   };
 
   return (
-    <FormCard
-      title={MENU_INFO.BASIC.TITLE}
-      guide={MENU_INFO.BASIC.GUIDE}
-      onSaveForm={handleSaveClick}
-    >
-      <Input
-        {...register('userInfo.name')}
-        id="name"
-        className="mb-3"
-        label={{ text: '이름', isRequired: true }}
-        placeholder={PLACEHOLDER.USER_INFO.NAME}
-        error={errors.userInfo?.name?.message}
-      />
-      <Input
-        {...register('userInfo.career')}
-        id="career"
-        className="mb-3"
-        label={{ text: '직무', isRequired: true }}
-        placeholder={PLACEHOLDER.USER_INFO.CAREER}
-        error={errors.userInfo?.career?.message}
-      />
-      <Input
-        {...register('userInfo.phone')}
-        id="phone"
-        type="tel"
-        className="mb-3"
-        label={{ text: '전화번호' }}
-        placeholder={PLACEHOLDER.USER_INFO.PHONE}
-        error={errors.userInfo?.phone?.message}
-      />
-      <Input
-        {...register('userInfo.email')}
-        id="email"
-        type="email"
-        className="mb-3"
-        label={{ text: '이메일', isRequired: true }}
-        placeholder={PLACEHOLDER.USER_INFO.EMAIL}
-        error={errors.userInfo?.email?.message}
-      />
-      <Input
-        {...register('userInfo.blog')}
-        id="blog"
-        className="mb-3"
-        label={{ text: '블로그' }}
-        placeholder={PLACEHOLDER.USER_INFO.URL}
-        error={errors.userInfo?.blog?.message}
-      />
-      <Input
-        {...register('userInfo.github')}
-        id="github"
-        className="mb-3"
-        label={{ text: '깃허브', isRequired: true }}
-        placeholder={PLACEHOLDER.USER_INFO.URL}
-        error={errors.userInfo?.github?.message}
-      />
-      <Label htmlFor="brief">소개글</Label>
-      <Textarea
-        {...register('userInfo.brief')}
-        id="brief"
-        placeholder={PLACEHOLDER.USER_INFO.BRIEF}
-      />
+    <FormCard title={MENU_INFO.BASIC.TITLE} guide={MENU_INFO.BASIC.GUIDE}>
+      <div className="mt-5">
+        <Input
+          {...register('userInfo.name')}
+          id="name"
+          className="mb-3"
+          label={{ text: '이름', isRequired: true }}
+          placeholder={PLACEHOLDER.USER_INFO.NAME}
+          error={errors.userInfo?.name?.message}
+        />
+        <Input
+          {...register('userInfo.career')}
+          id="career"
+          className="mb-3"
+          label={{ text: '직무', isRequired: true }}
+          placeholder={PLACEHOLDER.USER_INFO.CAREER}
+          error={errors.userInfo?.career?.message}
+        />
+        <Input
+          {...register('userInfo.phone')}
+          id="phone"
+          type="tel"
+          className="mb-3"
+          label={{ text: '전화번호' }}
+          placeholder={PLACEHOLDER.USER_INFO.PHONE}
+          error={errors.userInfo?.phone?.message}
+        />
+        <Input
+          {...register('userInfo.email')}
+          id="email"
+          type="email"
+          className="mb-3"
+          label={{ text: '이메일', isRequired: true }}
+          placeholder={PLACEHOLDER.USER_INFO.EMAIL}
+          error={errors.userInfo?.email?.message}
+        />
+        <Input
+          {...register('userInfo.blog')}
+          id="blog"
+          className="mb-3"
+          label={{ text: '블로그' }}
+          placeholder={PLACEHOLDER.USER_INFO.URL}
+          error={errors.userInfo?.blog?.message}
+        />
+        <Input
+          {...register('userInfo.github')}
+          id="github"
+          className="mb-3"
+          label={{ text: '깃허브', isRequired: true }}
+          placeholder={PLACEHOLDER.USER_INFO.URL}
+          error={errors.userInfo?.github?.message}
+        />
+        <Label htmlFor="brief">소개글</Label>
+        <Textarea
+          {...register('userInfo.brief')}
+          id="brief"
+          placeholder={PLACEHOLDER.USER_INFO.BRIEF}
+        />
+      </div>
+      <div className="ml-auto mt-4 w-fit">
+        <Button type="button" onClick={handleSaveClick}>
+          저장
+        </Button>
+      </div>
     </FormCard>
   );
 };

--- a/src/app/(editor)/basic/page.tsx
+++ b/src/app/(editor)/basic/page.tsx
@@ -20,19 +20,11 @@ const Page = () => {
   const handleSaveClick = () => {
     trigger('userInfo');
 
-    const formValues = getValues('userInfo');
-
-    if (
-      !formValues.name ||
-      !formValues.career ||
-      !formValues.email ||
-      !formValues.github ||
-      errors.userInfo
-    ) {
+    if (errors.userInfo) {
       return;
     }
 
-    storage.set({ ...storage.get(), userInfo: formValues });
+    storage.set({ ...storage.get(), userInfo: getValues('userInfo') });
   };
 
   return (

--- a/src/app/(editor)/experience/page.tsx
+++ b/src/app/(editor)/experience/page.tsx
@@ -33,7 +33,7 @@ const Page = () => {
     register,
     trigger,
     getValues,
-    formState: { errors, dirtyFields },
+    formState: { errors },
   } = useFormContext<ExperienceFormDataSchema>();
 
   const { fields, append, remove } = useFieldArray({
@@ -51,24 +51,20 @@ const Page = () => {
   const handleRemoveClick = (index: number) => {
     remove(index);
 
-    const formValues = getValues('experiences');
-
     storage.set({
       ...storage.get(),
-      experiences: formValues,
+      experiences: getValues('experiences'),
     });
   };
 
   const handleSaveClick = () => {
     trigger('experiences');
 
-    const formValues = getValues('experiences');
-
-    if (!dirtyFields.experiences || errors.experiences || !formValues.length) {
+    if (errors.experiences) {
       return;
     }
 
-    storage.set({ ...storage.get(), experiences: formValues });
+    storage.set({ ...storage.get(), experiences: getValues('experiences') });
   };
 
   return (

--- a/src/app/(editor)/experience/page.tsx
+++ b/src/app/(editor)/experience/page.tsx
@@ -3,7 +3,7 @@
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 import { v4 } from 'uuid';
 
-import { Input, Label } from '@/components/common';
+import { Button, Input, Label } from '@/components/common';
 import {
   Select,
   SelectContent,
@@ -72,83 +72,94 @@ const Page = () => {
       title={MENU_INFO.EXPERIENCE.TITLE}
       guide={MENU_INFO.EXPERIENCE.GUIDE}
       onAppendForm={handleAppendClick}
-      onSaveForm={handleSaveClick}
     >
-      <ul>
-        {fields.map((item, index) => (
-          <li key={item.id} className="border-b border-gray-200/70 py-6">
-            <div className="mb-3 flex items-end gap-2">
-              <Input
-                {...register(`experiences.${index}.company`)}
-                id="title"
-                className="mr-1"
-                label={{ text: '회사명', isRequired: true }}
-                placeholder={PLACEHOLDER.EXPERIENCE.COMPANY}
-                error={errors.experiences?.[index]?.company?.message}
-                autoFocus
-              />
-              <FormRemoveButton onRemoveForm={() => handleRemoveClick(index)} />
-            </div>
-            <div className="mb-3 flex flex-col gap-3 md:flex-row md:gap-2">
-              <div className="flex-1">
-                <Label htmlFor="employmentType" isRequired>
-                  근무 형태
-                </Label>
-                <Controller
-                  control={control}
-                  name={`experiences.${index}.employmentType`}
-                  render={({ field: { onChange, value } }) => (
-                    <Select onValueChange={onChange} defaultValue={value}>
-                      <SelectTrigger
-                        error={
-                          errors.experiences?.[index]?.employmentType?.message
-                        }
-                      >
-                        <SelectValue placeholder="근무 형태" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {EMPLOYMENT_TYPES.map((employmentType) => (
-                          <SelectItem
-                            key={employmentType}
-                            value={employmentType}
+      {fields.length > 0 && (
+        <div className="mt-5">
+          <ul>
+            {fields.map((item, index) => (
+              <li key={item.id} className="border-b border-gray-200/70 py-6">
+                <div className="mb-3 flex items-end gap-2">
+                  <Input
+                    {...register(`experiences.${index}.company`)}
+                    id="title"
+                    className="mr-1"
+                    label={{ text: '회사명', isRequired: true }}
+                    placeholder={PLACEHOLDER.EXPERIENCE.COMPANY}
+                    error={errors.experiences?.[index]?.company?.message}
+                    autoFocus
+                  />
+                  <FormRemoveButton
+                    onRemoveForm={() => handleRemoveClick(index)}
+                  />
+                </div>
+                <div className="mb-3 flex flex-col gap-3 md:flex-row md:gap-2">
+                  <div className="flex-1">
+                    <Label htmlFor="employmentType" isRequired>
+                      근무 형태
+                    </Label>
+                    <Controller
+                      control={control}
+                      name={`experiences.${index}.employmentType`}
+                      render={({ field: { onChange, value } }) => (
+                        <Select onValueChange={onChange} defaultValue={value}>
+                          <SelectTrigger
+                            error={
+                              errors.experiences?.[index]?.employmentType
+                                ?.message
+                            }
                           >
-                            {employmentType}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  )}
+                            <SelectValue placeholder="근무 형태" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {EMPLOYMENT_TYPES.map((employmentType) => (
+                              <SelectItem
+                                key={employmentType}
+                                value={employmentType}
+                              >
+                                {employmentType}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      )}
+                    />
+                  </div>
+                  <div className="flex-1">
+                    <Input
+                      {...register(`experiences.${index}.jobTitle`)}
+                      id="jobTitle"
+                      label={{ text: '직무', isRequired: true }}
+                      placeholder={PLACEHOLDER.EXPERIENCE.JOB_TITLE}
+                      error={errors.experiences?.[index]?.jobTitle?.message}
+                    />
+                  </div>
+                </div>
+                <PeriodInput
+                  formName="experiences"
+                  index={index}
+                  label={PERIOD_LABEL.WORKING}
+                  error={{
+                    startDate: errors.experiences?.[index]?.startDate?.message,
+                    endDate: errors.experiences?.[index]?.endDate?.message,
+                  }}
                 />
-              </div>
-              <div className="flex-1">
-                <Input
-                  {...register(`experiences.${index}.jobTitle`)}
-                  id="jobTitle"
-                  label={{ text: '직무', isRequired: true }}
-                  placeholder={PLACEHOLDER.EXPERIENCE.JOB_TITLE}
-                  error={errors.experiences?.[index]?.jobTitle?.message}
+                <MarkdownInput
+                  formName="experiences"
+                  index={index}
+                  label="내용"
+                  placeholder={PLACEHOLDER.EXPERIENCE.CONTENT}
+                  error={errors.experiences?.[index]?.content?.message}
                 />
-              </div>
-            </div>
-            <PeriodInput
-              formName="experiences"
-              index={index}
-              label={PERIOD_LABEL.WORKING}
-              error={{
-                startDate: errors.experiences?.[index]?.startDate?.message,
-                endDate: errors.experiences?.[index]?.endDate?.message,
-              }}
-            />
-            <MarkdownInput
-              formName="experiences"
-              index={index}
-              label="내용"
-              placeholder={PLACEHOLDER.EXPERIENCE.CONTENT}
-              error={errors.experiences?.[index]?.content?.message}
-            />
-          </li>
-        ))}
-      </ul>
+              </li>
+            ))}
+          </ul>
+          <div className="ml-auto mt-4 w-fit">
+            <Button type="button" onClick={handleSaveClick}>
+              저장
+            </Button>
+          </div>
+        </div>
+      )}
     </FormCard>
   );
 };

--- a/src/app/(editor)/experience/page.tsx
+++ b/src/app/(editor)/experience/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect } from 'react';
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
 import { v4 } from 'uuid';
 
@@ -26,9 +25,7 @@ import {
 } from '@/constants/form';
 import { MENU_INFO } from '@/constants/menu';
 import { type ExperienceFormDataSchema } from '@/types/form';
-import { storage, STORAGE_KEY } from '@/utils/storage';
-
-const webStorage = storage(STORAGE_KEY.EXPERIENCE);
+import { storage } from '@/utils/storage';
 
 const Page = () => {
   const {
@@ -36,7 +33,6 @@ const Page = () => {
     register,
     trigger,
     getValues,
-    setValue,
     formState: { errors, dirtyFields },
   } = useFormContext<ExperienceFormDataSchema>();
 
@@ -44,15 +40,6 @@ const Page = () => {
     name: 'experiences',
     control,
   });
-
-  useEffect(() => {
-    const storageData = webStorage.get();
-
-    setValue(
-      'experiences',
-      storageData ? storageData : [INITIAL_VALUE.EXPERIENCE]
-    );
-  }, [setValue]);
 
   const handleAppendClick = () => {
     append({
@@ -66,7 +53,10 @@ const Page = () => {
 
     const formValues = getValues('experiences');
 
-    webStorage.set(formValues.length ? formValues : [INITIAL_VALUE.EXPERIENCE]);
+    storage.set({
+      ...storage.get(),
+      experiences: formValues,
+    });
   };
 
   const handleSaveClick = () => {
@@ -78,7 +68,7 @@ const Page = () => {
       return;
     }
 
-    webStorage.set(formValues);
+    storage.set({ ...storage.get(), experiences: formValues });
   };
 
   return (

--- a/src/app/(editor)/layout.tsx
+++ b/src/app/(editor)/layout.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import SubmitButton from '@/components/Form/SubmitButton';
 import Sidebar from '@/components/Layout/Sidebar';
 import FormProvider from '@/components/Providers/FormProvider';
 
@@ -8,11 +7,8 @@ const Layout = ({ children }: StrictPropsWithChildren) => {
   return (
     <main className="mx-auto my-4 max-w-[1200px] px-4 sm:my-6 sm:px-6">
       <FormProvider>
-        <div className="flex flex-col gap-6 md:flex-row-reverse">
-          <div className="flex min-w-[260px] flex-col">
-            <Sidebar />
-            <SubmitButton />
-          </div>
+        <div className="flex flex-col gap-6 md:flex-row-reverse md:justify-center">
+          <Sidebar />
           {children}
         </div>
       </FormProvider>

--- a/src/app/(editor)/project/page.tsx
+++ b/src/app/(editor)/project/page.tsx
@@ -27,7 +27,7 @@ const Page = () => {
     register,
     trigger,
     getValues,
-    formState: { errors, dirtyFields },
+    formState: { errors },
   } = useFormContext<ProjectsFormDataSchema>();
 
   const { fields, append, remove } = useFieldArray({
@@ -54,28 +54,16 @@ const Page = () => {
     const newIsSuggest = isSuggest.slice().splice(index, 1);
     setIsSuggest(newIsSuggest);
 
-    const formValues = getValues('projects');
-
     storage.set({
       ...storage.get(),
-      activities: formValues,
+      activities: getValues('projects'),
     });
   };
 
   const handleSuggestClick = (index: number) => {
     trigger(`projects.${index}`);
 
-    const { title, startDate, endDate, content } = getValues(
-      `projects.${index}`
-    );
-
-    if (
-      !title ||
-      !startDate ||
-      !endDate ||
-      !content ||
-      errors.projects?.[index]
-    ) {
+    if (errors.projects?.[index]) {
       return;
     }
 
@@ -84,19 +72,17 @@ const Page = () => {
 
     setIsSuggest(newIsSuggest);
 
-    complete(content);
+    complete(getValues(`projects.${index}.content`));
   };
 
   const handleSaveClick = () => {
     trigger('projects');
 
-    const formValues = getValues('projects');
-
-    if (!dirtyFields.projects || errors.projects || !formValues.length) {
+    if (errors.projects) {
       return;
     }
 
-    storage.set({ ...storage.get(), projects: formValues });
+    storage.set({ ...storage.get(), projects: getValues('projects') });
   };
 
   return (

--- a/src/app/(editor)/project/page.tsx
+++ b/src/app/(editor)/project/page.tsx
@@ -131,7 +131,7 @@ const Page = () => {
                   {...register(`projects.${index}.url`)}
                   id="url"
                   className="mb-3"
-                  label={{ text: '프로젝트 주소', isRequired: true }}
+                  label={{ text: '프로젝트 주소' }}
                   placeholder={PLACEHOLDER.PROJECT.URL}
                 />
                 <MarkdownInput

--- a/src/app/(editor)/project/page.tsx
+++ b/src/app/(editor)/project/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCompletion } from 'ai/react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { v4 } from 'uuid';
 
@@ -17,9 +17,7 @@ import IconChatGpt from '@/components/Icon/IconChatGpt';
 import { INITIAL_VALUE, PLACEHOLDER } from '@/constants/form';
 import { MENU_INFO } from '@/constants/menu';
 import { type ProjectsFormDataSchema } from '@/types/form';
-import { storage, STORAGE_KEY } from '@/utils/storage';
-
-const webStorage = storage(STORAGE_KEY.PROJECT);
+import { storage } from '@/utils/storage';
 
 const Page = () => {
   const [isSuggest, setIsSuggest] = useState<boolean[]>([]);
@@ -29,7 +27,6 @@ const Page = () => {
     register,
     trigger,
     getValues,
-    setValue,
     formState: { errors, dirtyFields },
   } = useFormContext<ProjectsFormDataSchema>();
 
@@ -41,12 +38,6 @@ const Page = () => {
   const { complete, completion } = useCompletion({
     api: '/api/ai',
   });
-
-  useEffect(() => {
-    const storageData = webStorage.get();
-
-    setValue('projects', storageData ? storageData : [INITIAL_VALUE.PROJECT]);
-  }, [setValue]);
 
   const handleAppendClick = () => {
     append({
@@ -65,7 +56,10 @@ const Page = () => {
 
     const formValues = getValues('projects');
 
-    webStorage.set(formValues.length ? formValues : [INITIAL_VALUE.PROJECT]);
+    storage.set({
+      ...storage.get(),
+      activities: formValues,
+    });
   };
 
   const handleSuggestClick = (index: number) => {
@@ -102,7 +96,7 @@ const Page = () => {
       return;
     }
 
-    webStorage.set(formValues);
+    storage.set({ ...storage.get(), projects: formValues });
   };
 
   return (

--- a/src/app/(editor)/project/page.tsx
+++ b/src/app/(editor)/project/page.tsx
@@ -90,60 +90,70 @@ const Page = () => {
       title={MENU_INFO.PROJECT.TITLE}
       guide={MENU_INFO.PROJECT.GUIDE}
       onAppendForm={handleAppendClick}
-      onSaveForm={handleSaveClick}
     >
-      <ul>
-        {fields.map((item, index) => (
-          <li key={item.id} className="border-b border-gray-200/70 py-6">
-            <div className="mb-3 flex items-end gap-1">
-              <Input
-                {...register(`projects.${index}.title`)}
-                id="title"
-                className="mr-1"
-                label={{ text: '프로젝트명', isRequired: true }}
-                placeholder={PLACEHOLDER.PROJECT.TITLE}
-                error={errors.projects?.[index]?.title?.message}
-              />
-              <FormRemoveButton onRemoveForm={() => handleRemoveClick(index)} />
-              <Button
-                size="icon"
-                type="button"
-                className="ml-1"
-                disabled={isSuggest[index]}
-                title="프로젝트에 관련된 내용을 자세하게 작성할수록 첨삭 퀄리티가 높아져요."
-                onClick={() => handleSuggestClick(index)}
-              >
-                <IconChatGpt />
-              </Button>
-            </div>
-            <PeriodInput
-              formName="projects"
-              index={index}
-              error={{
-                startDate: errors.projects?.[index]?.startDate?.message,
-                endDate: errors.projects?.[index]?.endDate?.message,
-              }}
-            />
-            <Input
-              {...register(`projects.${index}.url`)}
-              id="url"
-              className="mb-3"
-              label={{ text: '프로젝트 주소', isRequired: true }}
-              placeholder={PLACEHOLDER.PROJECT.URL}
-            />
-            <MarkdownInput
-              formName="projects"
-              index={index}
-              label="프로젝트 내용"
-              placeholder={PLACEHOLDER.PROJECT.CONTENT}
-              error={errors.projects?.[index]?.content?.message}
-            />
-            {isSuggest[index] && completion && (
-              <AiSuggestion aiSuggestion={completion} />
-            )}
-          </li>
-        ))}
-      </ul>
+      {fields.length > 0 && (
+        <div className="mt-5">
+          <ul>
+            {fields.map((item, index) => (
+              <li key={item.id} className="border-b border-gray-200/70 py-6">
+                <div className="mb-3 flex items-end gap-1">
+                  <Input
+                    {...register(`projects.${index}.title`)}
+                    id="title"
+                    className="mr-1"
+                    label={{ text: '프로젝트명', isRequired: true }}
+                    placeholder={PLACEHOLDER.PROJECT.TITLE}
+                    error={errors.projects?.[index]?.title?.message}
+                  />
+                  <FormRemoveButton
+                    onRemoveForm={() => handleRemoveClick(index)}
+                  />
+                  <Button
+                    size="icon"
+                    type="button"
+                    className="ml-1"
+                    disabled={isSuggest[index]}
+                    title="프로젝트에 관련된 내용을 자세하게 작성할수록 첨삭 퀄리티가 높아져요."
+                    onClick={() => handleSuggestClick(index)}
+                  >
+                    <IconChatGpt />
+                  </Button>
+                </div>
+                <PeriodInput
+                  formName="projects"
+                  index={index}
+                  error={{
+                    startDate: errors.projects?.[index]?.startDate?.message,
+                    endDate: errors.projects?.[index]?.endDate?.message,
+                  }}
+                />
+                <Input
+                  {...register(`projects.${index}.url`)}
+                  id="url"
+                  className="mb-3"
+                  label={{ text: '프로젝트 주소', isRequired: true }}
+                  placeholder={PLACEHOLDER.PROJECT.URL}
+                />
+                <MarkdownInput
+                  formName="projects"
+                  index={index}
+                  label="프로젝트 내용"
+                  placeholder={PLACEHOLDER.PROJECT.CONTENT}
+                  error={errors.projects?.[index]?.content?.message}
+                />
+                {isSuggest[index] && completion && (
+                  <AiSuggestion aiSuggestion={completion} />
+                )}
+              </li>
+            ))}
+          </ul>
+          <div className="ml-auto mt-4 w-fit">
+            <Button type="button" onClick={handleSaveClick}>
+              저장
+            </Button>
+          </div>
+        </div>
+      )}
     </FormCard>
   );
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import META from '@/constants/meta';
 import { pretendard, sourceCode } from '@/styles/font';
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://careerboost-bmt142ael-dmswl98.vercel.app'),
   title: META.TITLE,
   description: META.DESCRIPTION,
   keywords: [...META.KEYWORD],

--- a/src/components/Form/FormCard.tsx
+++ b/src/components/Form/FormCard.tsx
@@ -6,7 +6,6 @@ interface FormCardProps {
   title: string;
   guide?: string;
   onAppendForm?: () => void;
-  onSaveForm: () => void;
 }
 
 const FormCard = ({
@@ -14,10 +13,9 @@ const FormCard = ({
   title,
   guide,
   onAppendForm,
-  onSaveForm,
 }: StrictPropsWithChildren<FormCardProps>) => {
   return (
-    <div className="w-full rounded-xl border border-gray-200/70 bg-white p-6 md:w-[800px] md:p-8">
+    <div className="h-fit w-full rounded-xl border border-gray-200/70 bg-white p-6 md:w-[800px] md:p-8">
       <div className="mb-3 flex justify-between">
         <h1 className="bg-white text-lg font-bold md:text-xl">{title}</h1>
         {onAppendForm && (
@@ -32,16 +30,11 @@ const FormCard = ({
         )}
       </div>
       {guide && (
-        <div className="mb-5 whitespace-pre-line rounded-lg bg-gray-100 p-4 text-sm text-gray-600">
+        <div className="whitespace-pre-line rounded-lg bg-gray-100 p-4 text-sm text-gray-600">
           {guide}
         </div>
       )}
       {children}
-      <div className="ml-auto mt-4 w-fit">
-        <Button type="button" onClick={onSaveForm}>
-          저장
-        </Button>
-      </div>
     </div>
   );
 };

--- a/src/components/Layout/DownloadButton.tsx
+++ b/src/components/Layout/DownloadButton.tsx
@@ -1,14 +1,40 @@
+import { PDFDownloadLink } from '@react-pdf/renderer';
+import { useFormContext } from 'react-hook-form';
+
 import { Button } from '@/components/common';
+import PdfDocument from '@/components/Pdf/PdfDocument';
+import { type ResumeFormDataSchema } from '@/types/form';
 
-interface DownloadButtonProps {
-  isError: boolean;
-}
+const DownloadButton = () => {
+  const {
+    getValues,
+    formState: { errors, isSubmitSuccessful },
+  } = useFormContext<ResumeFormDataSchema>();
 
-const DownloadButton = ({ isError }: DownloadButtonProps) => {
   return (
-    <Button type="submit" disabled={isError}>
-      이력서 다운로드
-    </Button>
+    <>
+      {isSubmitSuccessful ? (
+        <PDFDownloadLink
+          document={<PdfDocument resume={getValues()} />}
+          fileName={`${getValues('userInfo.name')}님의_이력서.pdf`}
+          style={{ width: '100%' }}
+        >
+          {({ loading, error }) => (
+            <Button
+              type="button"
+              className="w-full"
+              disabled={!!error || loading}
+            >
+              {loading ? '이력서 생성 중' : '이력서 다운로드'}
+            </Button>
+          )}
+        </PDFDownloadLink>
+      ) : (
+        <Button type="submit" disabled={!!Object.keys(errors).length}>
+          이력서 다운로드
+        </Button>
+      )}
+    </>
   );
 };
 

--- a/src/components/Layout/DownloadButton.tsx
+++ b/src/components/Layout/DownloadButton.tsx
@@ -31,7 +31,7 @@ const DownloadButton = () => {
         </PDFDownloadLink>
       ) : (
         <Button type="submit" disabled={!!Object.keys(errors).length}>
-          이력서 다운로드
+          이력서 생성
         </Button>
       )}
     </>

--- a/src/components/Layout/DownloadButton.tsx
+++ b/src/components/Layout/DownloadButton.tsx
@@ -1,0 +1,15 @@
+import { Button } from '@/components/common';
+
+interface DownloadButtonProps {
+  isError: boolean;
+}
+
+const DownloadButton = ({ isError }: DownloadButtonProps) => {
+  return (
+    <Button type="submit" disabled={isError}>
+      이력서 다운로드
+    </Button>
+  );
+};
+
+export default DownloadButton;

--- a/src/components/Layout/MenuLink.tsx
+++ b/src/components/Layout/MenuLink.tsx
@@ -8,14 +8,14 @@ interface MenuLinkProps<T extends FieldValues> {
   isCurrentLocation: boolean;
   title: string;
   route: (typeof ROUTES)[keyof typeof ROUTES];
-  status?: FieldErrors<T>;
+  isError?: FieldErrors<T>;
 }
 
 const MenuLink = <T extends FieldValues>({
   isCurrentLocation,
   route,
   title,
-  status,
+  isError,
 }: MenuLinkProps<T>) => {
   const currentLocationStyle = isCurrentLocation
     ? 'border-primary font-bold text-primary'
@@ -29,7 +29,7 @@ const MenuLink = <T extends FieldValues>({
       >
         {title}
       </Link>
-      {status && <AlertCircle className="h-5 w-5 text-destructive" />}
+      {isError && <AlertCircle className="h-5 w-5 text-destructive" />}
     </li>
   );
 };

--- a/src/components/Layout/MenuLink.tsx
+++ b/src/components/Layout/MenuLink.tsx
@@ -1,31 +1,37 @@
+import { AlertCircle } from 'lucide-react';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { type FieldErrors, type FieldValues } from 'react-hook-form';
 
 import { type ROUTES } from '@/constants/routes';
 
-interface SidebarMenuProps {
+interface MenuLinkProps<T extends FieldValues> {
+  isCurrentLocation: boolean;
   title: string;
   route: (typeof ROUTES)[keyof typeof ROUTES];
+  status?: FieldErrors<T>;
 }
 
-const SidebarMenu = ({ title, route }: SidebarMenuProps) => {
-  const pathname = usePathname();
-
-  const isCurrentLocation = pathname === route;
+const MenuLink = <T extends FieldValues>({
+  isCurrentLocation,
+  route,
+  title,
+  status,
+}: MenuLinkProps<T>) => {
   const currentLocationStyle = isCurrentLocation
     ? 'border-primary font-bold text-primary'
     : 'border-white text-gray-400';
 
   return (
-    <li className="my-3 text-[15px] last:mb-0">
+    <li className="my-3 flex items-center justify-between text-[15px] last:mb-0">
       <Link
         href={route}
         className={`inline-block border-b-[3px] py-1 transition-all hover:border-primary hover:font-bold hover:text-primary ${currentLocationStyle}`}
       >
         {title}
       </Link>
+      {status && <AlertCircle className="h-5 w-5 text-destructive" />}
     </li>
   );
 };
 
-export default SidebarMenu;
+export default MenuLink;

--- a/src/components/Layout/PreviewButton.tsx
+++ b/src/components/Layout/PreviewButton.tsx
@@ -3,7 +3,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import { Switch } from '@/components/common';
 import { ROUTES } from '@/constants/routes';
 
-const SubmitButton = () => {
+const PreviewButton = () => {
   const router = useRouter();
   const pathname = usePathname();
 
@@ -12,7 +12,7 @@ const SubmitButton = () => {
   };
 
   return (
-    <div className="flex w-full items-center justify-between rounded-xl bg-gray-100/80 px-5 py-4">
+    <div className="mb-4 flex w-full items-center justify-between rounded-xl bg-gray-100/80 px-5 py-4">
       <div className="grow text-sm font-bold text-primary">이력서 미리보기</div>
       <Switch
         checked={pathname === ROUTES.PREVIEW}
@@ -22,4 +22,4 @@ const SubmitButton = () => {
   );
 };
 
-export default SubmitButton;
+export default PreviewButton;

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,18 +1,61 @@
-import { Progress } from '@/components/common';
-import { SIDEBAR_MENU } from '@/constants/menu';
+import { usePathname } from 'next/navigation';
+import { useFormContext } from 'react-hook-form';
 
-import SidebarMenu from './SidebarMenu';
+import { Progress } from '@/components/common';
+import { MENU_INFO } from '@/constants/menu';
+import type {
+  ActivitiesFormDataSchema,
+  ExperienceFormDataSchema,
+  ProjectsFormDataSchema,
+  ResumeFormDataSchema,
+  UserInfoFormDataSchema,
+} from '@/types/form';
+
+import DownloadButton from './DownloadButton';
+import MenuLink from './MenuLink';
+import PreviewButton from './PreviewButton';
 
 const Sidebar = () => {
+  const pathname = usePathname();
+
+  const {
+    formState: { errors },
+  } = useFormContext<ResumeFormDataSchema>();
+
   return (
-    <aside className="mb-2 h-fit rounded-xl border border-gray-200/70 bg-white px-5 py-7 md:mb-6">
-      <h1 className="mb-2 text-base font-bold">이력서 완성도</h1>
-      <Progress value={30} />
-      <ul className="mt-6">
-        {SIDEBAR_MENU.map((menu) => (
-          <SidebarMenu key={menu.title} title={menu.title} route={menu.route} />
-        ))}
-      </ul>
+    <aside className="flex h-fit min-w-[260px] flex-col">
+      <div className="mb-2 rounded-xl border border-gray-200/70 bg-white px-5 py-7 md:mb-6">
+        <h1 className="mb-2 text-base font-bold">이력서 완성도</h1>
+        <Progress value={30} />
+        <ul className="mt-6">
+          <MenuLink<UserInfoFormDataSchema>
+            isCurrentLocation={pathname === MENU_INFO.BASIC.ROUTE}
+            title={MENU_INFO.BASIC.TITLE}
+            route={MENU_INFO.BASIC.ROUTE}
+            status={errors.userInfo}
+          />
+          <MenuLink<ExperienceFormDataSchema>
+            isCurrentLocation={pathname === MENU_INFO.EXPERIENCE.ROUTE}
+            title={MENU_INFO.EXPERIENCE.TITLE}
+            route={MENU_INFO.EXPERIENCE.ROUTE}
+            status={errors.experiences}
+          />
+          <MenuLink<ProjectsFormDataSchema>
+            isCurrentLocation={pathname === MENU_INFO.PROJECT.ROUTE}
+            title={MENU_INFO.PROJECT.TITLE}
+            route={MENU_INFO.PROJECT.ROUTE}
+            status={errors.projects}
+          />
+          <MenuLink<ActivitiesFormDataSchema>
+            isCurrentLocation={pathname === MENU_INFO.ACTIVITY.ROUTE}
+            title={MENU_INFO.ACTIVITY.TITLE}
+            route={MENU_INFO.ACTIVITY.ROUTE}
+            status={errors.activities}
+          />
+        </ul>
+      </div>
+      <PreviewButton />
+      <DownloadButton isError={!!Object.keys(errors).length} />
     </aside>
   );
 };

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -32,25 +32,25 @@ const Sidebar = () => {
             isCurrentLocation={pathname === MENU_INFO.BASIC.ROUTE}
             title={MENU_INFO.BASIC.TITLE}
             route={MENU_INFO.BASIC.ROUTE}
-            status={errors.userInfo}
+            isError={errors.userInfo}
           />
           <MenuLink<ExperienceFormDataSchema>
             isCurrentLocation={pathname === MENU_INFO.EXPERIENCE.ROUTE}
             title={MENU_INFO.EXPERIENCE.TITLE}
             route={MENU_INFO.EXPERIENCE.ROUTE}
-            status={errors.experiences}
+            isError={errors.experiences}
           />
           <MenuLink<ProjectsFormDataSchema>
             isCurrentLocation={pathname === MENU_INFO.PROJECT.ROUTE}
             title={MENU_INFO.PROJECT.TITLE}
             route={MENU_INFO.PROJECT.ROUTE}
-            status={errors.projects}
+            isError={errors.projects}
           />
           <MenuLink<ActivitiesFormDataSchema>
             isCurrentLocation={pathname === MENU_INFO.ACTIVITY.ROUTE}
             title={MENU_INFO.ACTIVITY.TITLE}
             route={MENU_INFO.ACTIVITY.ROUTE}
-            status={errors.activities}
+            isError={errors.activities}
           />
         </ul>
       </div>

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -10,6 +10,7 @@ import type {
   ResumeFormDataSchema,
   UserInfoFormDataSchema,
 } from '@/types/form';
+import { calculateProgressValue } from '@/utils/progress';
 
 import DownloadButton from './DownloadButton';
 import MenuLink from './MenuLink';
@@ -19,6 +20,7 @@ const Sidebar = () => {
   const pathname = usePathname();
 
   const {
+    getValues,
     formState: { errors },
   } = useFormContext<ResumeFormDataSchema>();
 
@@ -26,7 +28,14 @@ const Sidebar = () => {
     <aside className="flex h-fit min-w-[260px] flex-col">
       <div className="mb-2 rounded-xl border border-gray-200/70 bg-white px-5 py-7 md:mb-6">
         <h1 className="mb-2 text-base font-bold">이력서 완성도</h1>
-        <Progress value={30} />
+        <Progress
+          value={calculateProgressValue(
+            getValues('experiences').length,
+            getValues('projects').length,
+            getValues('activities').length,
+            Object.keys(errors).length
+          )}
+        />
         <ul className="mt-6">
           <MenuLink<UserInfoFormDataSchema>
             isCurrentLocation={pathname === MENU_INFO.BASIC.ROUTE}
@@ -55,7 +64,7 @@ const Sidebar = () => {
         </ul>
       </div>
       <PreviewButton />
-      <DownloadButton isError={!!Object.keys(errors).length} />
+      <DownloadButton />
     </aside>
   );
 };

--- a/src/components/Pdf/PdfUserInfo.tsx
+++ b/src/components/Pdf/PdfUserInfo.tsx
@@ -13,7 +13,7 @@ const PdfUserInfo = ({ userInfo }: PdfUserInfoProps) => {
   return (
     <View
       style={tailwind(
-        'flex-column justify-between bg-gray-100 text-gray-500 p-8 mt-[-29px] mx-[-23px]'
+        'flex-col justify-between bg-gray-100 text-gray-500 p-8 mt-[-29px] mx-[-23px]'
       )}
     >
       <View style={tailwind('flex-row')}>

--- a/src/components/Providers/FormProvider.tsx
+++ b/src/components/Providers/FormProvider.tsx
@@ -8,7 +8,7 @@ import { storage } from '@/utils/storage';
 
 const FormProvider = ({ children }: StrictPropsWithChildren) => {
   const methods = useForm<ResumeFormDataSchema>({
-    mode: 'onChange',
+    mode: 'all',
     resolver: zodResolver(resumeFormSchema),
     defaultValues: {
       userInfo: INITIAL_VALUE.USER_INFO,

--- a/src/components/Providers/FormProvider.tsx
+++ b/src/components/Providers/FormProvider.tsx
@@ -1,22 +1,37 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect } from 'react';
 import { FormProvider as Provider, useForm } from 'react-hook-form';
 
 import { INITIAL_VALUE } from '@/constants/form';
 import { type ResumeFormDataSchema, resumeFormSchema } from '@/types/form';
-
-const FORM_DEFAULT_VALUES = {
-  userInfo: INITIAL_VALUE.USER_INFO,
-  experiences: [INITIAL_VALUE.EXPERIENCE],
-  projects: [INITIAL_VALUE.PROJECT],
-  activities: [INITIAL_VALUE.ACTIVITY],
-};
+import { storage } from '@/utils/storage';
 
 const FormProvider = ({ children }: StrictPropsWithChildren) => {
   const methods = useForm<ResumeFormDataSchema>({
     mode: 'onChange',
     resolver: zodResolver(resumeFormSchema),
-    defaultValues: FORM_DEFAULT_VALUES,
+    defaultValues: {
+      userInfo: INITIAL_VALUE.USER_INFO,
+      experiences: [],
+      projects: [],
+      activities: [],
+    },
   });
+
+  useEffect(() => {
+    const storageData = storage.get();
+
+    if (!storageData) {
+      return;
+    }
+
+    const { userInfo, experiences, projects, activities } = storageData;
+
+    methods.setValue('userInfo', userInfo);
+    methods.setValue('experiences', experiences);
+    methods.setValue('projects', projects);
+    methods.setValue('activities', activities);
+  }, [methods]);
 
   const onSubmit = (data: ResumeFormDataSchema) => {
     methods.trigger();

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -3,7 +3,7 @@ import { clsx } from 'clsx';
 import { type ComponentPropsWithoutRef, forwardRef } from 'react';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/src/constants/menu.ts
+++ b/src/constants/menu.ts
@@ -4,39 +4,24 @@ export const MENU_INFO = {
   BASIC: {
     TITLE: '기본 정보',
     GUIDE: '입력한 정보가 올바른지 다시 한 번 확인해주세요',
+    ROUTE: ROUTES.BASIC,
   },
   EXPERIENCE: {
     TITLE: '업무 경력',
     GUIDE:
       '💡 주도적으로 특정 기능 개발을 이끌어 달성한 구체적인 성과를 작성해 전문성과 협업 역량을 강조해보세요',
+    ROUTE: ROUTES.EXPERIENCE,
   },
   PROJECT: {
     TITLE: '프로젝트',
     GUIDE:
       '💡 단순히 어떤 기술을 사용했다는 것보다 해당 프로젝트에서 마주친 문제를 해결한 과정과 배운 점, 결과 등을 강조해보세요',
+    ROUTE: ROUTES.PROJECT,
   },
   ACTIVITY: {
     TITLE: '수상 및 활동',
     GUIDE:
       '💡 활동에 참여한 동기와 어떤 역량을 키울 수 있었는지 구체적으로 작성하여 지속적인 성장 의지와 전문성을 강조해보세요',
+    ROUTE: ROUTES.ACTIVITY,
   },
 } as const;
-
-export const SIDEBAR_MENU = [
-  {
-    title: MENU_INFO.BASIC.TITLE,
-    route: ROUTES.BASIC,
-  },
-  {
-    title: MENU_INFO.EXPERIENCE.TITLE,
-    route: ROUTES.EXPERIENCE,
-  },
-  {
-    title: MENU_INFO.PROJECT.TITLE,
-    route: ROUTES.PROJECT,
-  },
-  {
-    title: MENU_INFO.ACTIVITY.TITLE,
-    route: ROUTES.ACTIVITY,
-  },
-];

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -1,0 +1,20 @@
+const ROUND_DOWN_FACTOR = 10;
+
+export const calculateProgressValue = (
+  experiencesFormFieldCount: number,
+  projectsFormFieldCount: number,
+  activitiesFormFieldCount: number,
+  errorCount: number
+) => {
+  const hasExperienceForm = experiencesFormFieldCount && 1;
+  const hasProjectForm = projectsFormFieldCount && 1;
+  const hasActivityForm = activitiesFormFieldCount && 1;
+
+  const createdFormCount =
+    hasExperienceForm + hasProjectForm + hasActivityForm + 1;
+  const stepCount = 100 / createdFormCount;
+  const validFormCount = createdFormCount - errorCount;
+  const progress = stepCount * validFormCount;
+
+  return Math.floor(progress / ROUND_DOWN_FACTOR) * ROUND_DOWN_FACTOR;
+};

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,29 +1,11 @@
-import type {
-  ActivitiesFormDataSchema,
-  ExperienceFormDataSchema,
-  ProjectsFormDataSchema,
-  UserInfoFormDataSchema,
-} from '@/types/form';
+import type { ResumeFormDataSchema } from '@/types/form';
 
-const SERVICE_NAME = 'CAREERBOOST';
+export const STORAGE_KEY = 'CAREERBOOST';
 
-export const STORAGE_KEY = {
-  USER_INFO: `${SERVICE_NAME}_USER_INFO`,
-  EXPERIENCE: `${SERVICE_NAME}_EXPERIENCE`,
-  PROJECT: `${SERVICE_NAME}_PROJECT`,
-  ACTIVITY: `${SERVICE_NAME}_ACTIVITY`,
-} as const;
-
-type StorageKey = (typeof STORAGE_KEY)[keyof typeof STORAGE_KEY];
-type StorageValue =
-  | UserInfoFormDataSchema['userInfo']
-  | ExperienceFormDataSchema['experiences']
-  | ProjectsFormDataSchema['projects']
-  | ActivitiesFormDataSchema['activities'];
-
-export const storage = (key: StorageKey) => ({
-  get: () => JSON.parse(localStorage.getItem(key) as string),
-  set: (value: StorageValue) =>
-    localStorage.setItem(key, JSON.stringify(value)),
-  remove: () => localStorage.removeItem(key),
-});
+export const storage = {
+  get: (): ResumeFormDataSchema =>
+    JSON.parse(localStorage.getItem(STORAGE_KEY) as string),
+  set: (value: ResumeFormDataSchema) =>
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(value)),
+  remove: () => localStorage.removeItem(STORAGE_KEY),
+};


### PR DESCRIPTION
## 🎨 PDF 이력서 다운로드 기능 구현
- [x] 각 form별 유효성 검사가 통과되지 않은 경우, 해당 form menu에 에러 표시
- [x] 각 form별 데이터 객체 생성 -> FormProvider 컴포넌트 내부에서 하나의 데이터 객체로 통합 및 form 초기값 설정
- [x] useForm mode를 `all`로 변경해 trigger 함수가 제대로 동작하지 않는 문제 해결
- [x] 기존 FormCard 컴포넌트 내부에 존재하던 저장 버튼을 각 form 페이지 컴포넌트 하위로 이동
- [x] `@react-pdf/renderer`의 PDFDownloadLink를 이용해 이력서 다운로드 기능 구현
- [x] 이력서 완성도 구현

## 📌 metadataBase

```
 ⚠ metadata.metadataBase is not set for resolving social open graph 
or twitter images, using "http://localhost:3000". 
See https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase
```

metadata 내부에 metadatabase가 설정되지 않아 `og:image`에 해당하는 이미지 경로가 제대로 적용되지 않아 대신 로컬 주소(`http://localhost:3000`)로 설정되었다는 경고 발생

해결 방법은 배포된 페이지의 `og:image` 경로와 똑같이 맞춰주면 된다.

```ts
export const metadata: Metadata = {
  metadataBase: new URL('https://careerboost-bmt142ael-dmswl98.vercel.app'),
  // 생략
};
```

## 🖼️ 구현 스크린샷

https://github.com/dmswl98/careerboost/assets/76807107/6b499f4a-5e50-43af-8ac2-73622e0f0c0e

