### PR TITLE
chore: `Lighthouse CI` branches-ignore 설정

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,6 +1,10 @@
 name: Lighthouse CI
 
-on: pull_request
+on:
+  pull_request:
+    branches-ignore:
+      - 'dependabot/**'
+      - 'imgbot'
 
 jobs:
   lhci:


### PR DESCRIPTION
Lighthouse CI workflow 트리거하지 않을 브랜치 설정