### PR TITLE
feat: 접근성 향상

### DIFF
--- a/src/components/Form/ButtonGroup.tsx
+++ b/src/components/Form/ButtonGroup.tsx
@@ -26,6 +26,7 @@ const ButtonGroup = ({
           disabled={isTop}
           variant="outline"
           size="icon"
+          aria-label="위로 이동"
           onClick={onMoveUpForm}
         >
           <ChevronUp className="m-1 text-gray-500" />
@@ -36,6 +37,7 @@ const ButtonGroup = ({
           disabled={isBottom}
           variant="outline"
           size="icon"
+          aria-label="아래로 이동"
           onClick={onMoveDownForm}
         >
           <ChevronDown className="m-1 text-gray-500" />
@@ -46,6 +48,7 @@ const ButtonGroup = ({
         className="h-6 w-6"
         variant="outline"
         size="icon"
+        aria-label="삭제"
         onClick={onRemoveForm}
       >
         <X className="m-1 text-gray-500" />

--- a/src/components/Form/FormCard.tsx
+++ b/src/components/Form/FormCard.tsx
@@ -20,9 +20,10 @@ const FormCard = ({
         <h1 className="bg-white text-lg font-bold md:text-xl">{title}</h1>
         {onAppendForm && (
           <Button
+            type="button"
             variant="ghost"
             size="icon"
-            type="button"
+            aria-label={`${title} 작성 양식 추가`}
             onClick={onAppendForm}
           >
             <PlusCircle className="m-3" />

--- a/src/components/Form/FormErrorMessage.tsx
+++ b/src/components/Form/FormErrorMessage.tsx
@@ -6,12 +6,18 @@ interface FormErrorMessageProps extends HTMLAttributes<HTMLSpanElement> {
 }
 
 const FormErrorMessage = ({
+  id,
   message,
   className,
   ...props
 }: FormErrorMessageProps) => {
   return (
-    <span className={clsx('text-xs text-red-300', className)} {...props}>
+    <span
+      id={`error-message-${id}`}
+      role="alert"
+      className={clsx('text-xs text-red-300', className)}
+      {...props}
+    >
       {message}
     </span>
   );

--- a/src/components/Form/MarkdownInput.tsx
+++ b/src/components/Form/MarkdownInput.tsx
@@ -69,6 +69,7 @@ const MarkdownInput = ({
           id="content"
           className={`col-span-4 ${error ? 'border-red-300' : ''}`}
           placeholder={placeholder}
+          aria-errormessage={error}
           onChange={(e) => {
             register(
               `${formName}.${index}.content` as FieldPath<ResumeFormDataSchema>
@@ -77,7 +78,7 @@ const MarkdownInput = ({
           }}
         />
         <div className="mt-1 flex justify-between">
-          {error && <FormErrorMessage message={error} />}
+          {error && <FormErrorMessage id="content" message={error} />}
           <span className="ml-auto text-xs text-gray-300">
             글자수 {value?.length || 0}
           </span>

--- a/src/components/Form/PeriodInput.tsx
+++ b/src/components/Form/PeriodInput.tsx
@@ -36,6 +36,10 @@ const PeriodInput = ({
   const { register, watch, getValues, setValue, resetField } =
     useFormContext<ResumeFormDataSchema>();
 
+  const isChecked =
+    watch(`${formName}.${index}.endDate` as FieldPath<ResumeFormDataSchema>) ===
+    PERIOD_INPUT_PLACEHOLDER;
+
   const handleCheckboxClick = (index: number) => {
     const endDateField =
       `${formName}.${index}.endDate` as FieldPath<ResumeFormDataSchema>;
@@ -97,11 +101,7 @@ const PeriodInput = ({
         <Checkbox
           id={`isDoing-${index}`}
           label={label}
-          checked={
-            watch(
-              `${formName}.${index}.endDate` as FieldPath<ResumeFormDataSchema>
-            ) === PERIOD_INPUT_PLACEHOLDER
-          }
+          checked={isChecked}
           onClick={() => {
             handleCheckboxClick(index);
             handleAutoSave();

--- a/src/components/Layout/DownloadButton.tsx
+++ b/src/components/Layout/DownloadButton.tsx
@@ -25,13 +25,20 @@ const DownloadButton = () => {
               variant={!loading && !error ? 'success' : 'default'}
               className="w-full"
               disabled={loading || !!error}
+              aria-disabled={loading || !!error}
+              aria-label="이력서 다운로드하기"
             >
               {loading ? '이력서 생성 중' : '이력서 다운로드'}
             </Button>
           )}
         </PDFDownloadLink>
       ) : (
-        <Button type="submit" disabled={!!Object.keys(errors).length}>
+        <Button
+          type="submit"
+          disabled={!!Object.keys(errors).length}
+          aria-disabled={!!Object.keys(errors).length}
+          aria-label="이력서 생성하기"
+        >
           이력서 생성
         </Button>
       )}

--- a/src/components/Layout/MenuLink.tsx
+++ b/src/components/Layout/MenuLink.tsx
@@ -40,23 +40,32 @@ const MenuLink = <T extends FieldValues>({
     : 'opacity-30';
 
   return (
-    <li className="my-3 flex items-center justify-between text-[15px] last:mb-0">
+    <li
+      className="my-3 flex items-center justify-between text-[15px] last:mb-0"
+      aria-current={isCurrentLocation ? 'page' : 'false'}
+    >
       <Link
         href={route}
-        className={`inline-block border-b-[3px] py-1 transition-all hover:border-primary hover:font-bold hover:text-primary ${currentLocationMenuStyle}`}
+        className="flex w-full items-center justify-between hover:[&>span]:border-primary hover:[&>span]:font-bold hover:[&>span]:text-primary"
       >
-        {title}
+        <span
+          className={`border-b-[3px] py-1 transition-all ${currentLocationMenuStyle}`}
+        >
+          {title}
+        </span>
+        {isError && (
+          <AlertCircle
+            className={`h-5 w-5 text-destructive transition-all ${currentLocationIconStyle}`}
+            aria-label="작성 미완료 상태"
+          />
+        )}
+        {!isError && isCreatedForm && (
+          <CheckCircle2
+            className={`h-5 w-5 text-success transition-all ${currentLocationIconStyle}`}
+            aria-label="작성 완료 상태"
+          />
+        )}
       </Link>
-      {isError && (
-        <AlertCircle
-          className={`h-5 w-5 text-destructive transition-all ${currentLocationIconStyle}`}
-        />
-      )}
-      {!isError && isCreatedForm && (
-        <CheckCircle2
-          className={`h-5 w-5 text-success transition-all ${currentLocationIconStyle}`}
-        />
-      )}
     </li>
   );
 };

--- a/src/components/Layout/PreviewButton.tsx
+++ b/src/components/Layout/PreviewButton.tsx
@@ -7,6 +7,8 @@ const PreviewButton = () => {
   const router = useRouter();
   const pathname = usePathname();
 
+  const isChecked = pathname === ROUTES.PREVIEW;
+
   const handlePreviewNavigate = (isChecked: boolean) => {
     isChecked ? router.push(ROUTES.PREVIEW) : router.back();
   };
@@ -15,7 +17,8 @@ const PreviewButton = () => {
     <div className="mb-4 flex w-full items-center justify-between rounded-xl bg-gray-100/80 px-5 py-4">
       <div className="grow text-sm font-bold text-primary">이력서 미리보기</div>
       <Switch
-        checked={pathname === ROUTES.PREVIEW}
+        checked={isChecked}
+        aria-label="이력서 미리보기"
         onCheckedChange={(isChecked) => handlePreviewNavigate(isChecked)}
       />
     </div>

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -29,7 +29,10 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
               {label.text}
             </label>
             {label.isRequired && (
-              <span className="ml-1 inline-block text-xs text-gray-400 min-[470px]:mb-1.5">
+              <span
+                className="ml-1 inline-block text-xs text-gray-400 min-[470px]:mb-1.5"
+                aria-hidden
+              >
                 ✱
               </span>
             )}
@@ -37,6 +40,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
         )}
         {error && (
           <FormErrorMessage
+            id={id}
             className="absolute right-0 top-1.5"
             message={error}
           />
@@ -51,6 +55,10 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             }`,
             className
           )}
+          aria-label={id}
+          aria-required={label?.isRequired}
+          aria-invalid={error ? 'true' : 'false'}
+          aria-errormessage={`error-message-${id}`}
           {...props}
         />
       </div>

--- a/src/components/common/Label.tsx
+++ b/src/components/common/Label.tsx
@@ -17,7 +17,10 @@ const Label = forwardRef<HTMLLabelElement, LabelProps>(
         {...props}
       />
       {isRequired && (
-        <span className="ml-1 inline-block text-xs text-gray-400 min-[470px]:mb-1.5">
+        <span
+          className="ml-1 inline-block text-xs text-gray-400 min-[470px]:mb-1.5"
+          aria-hidden
+        >
           ✱
         </span>
       )}

--- a/src/components/common/ServiceErrorMessage.tsx
+++ b/src/components/common/ServiceErrorMessage.tsx
@@ -34,7 +34,9 @@ const ServiceErrorMessage = ({
     <div className="my-10 flex flex-col items-center justify-center">
       <p className="mb-1 text-xl font-bold">{title}</p>
       <p className="mb-4">{description}</p>
-      <Button onClick={handleNavigate}>{buttonContent}</Button>
+      <Button onClick={handleNavigate} aria-label={buttonContent}>
+        {buttonContent}
+      </Button>
     </div>
   );
 };

--- a/src/components/common/Switch.tsx
+++ b/src/components/common/Switch.tsx
@@ -11,13 +11,14 @@ import {
 const Switch = forwardRef<
   ElementRef<typeof SwitchPrimitives.Root>,
   ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
+>(({ checked, className, ...props }, ref) => (
   <SwitchPrimitives.Root
     ref={ref}
     className={clsx(
       'peer inline-flex h-[20px] w-[36px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-border',
       className
     )}
+    aria-checked={checked}
     {...props}
   >
     <SwitchPrimitives.Thumb

--- a/src/components/common/Textarea.tsx
+++ b/src/components/common/Textarea.tsx
@@ -8,10 +8,11 @@ export interface TextareaProps extends ComponentPropsWithoutRef<'textarea'> {
 }
 
 const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ error, className, ...props }, ref) => {
+  ({ id, error, className, ...props }, ref) => {
     return (
       <>
         <textarea
+          id={id}
           ref={ref}
           className={clsx(
             `flex h-[80px] w-full resize-none rounded-md border border-gray-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-sm placeholder:text-gray-300 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 ${
@@ -19,9 +20,12 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             }`,
             className
           )}
+          aria-label={id}
+          aria-invalid={error ? 'true' : 'false'}
+          aria-errormessage={`error-message-${id}`}
           {...props}
         />
-        {error && <FormErrorMessage message={error} />}
+        {error && <FormErrorMessage id={id} message={error} />}
       </>
     );
   }

--- a/src/features/Home/Footer.tsx
+++ b/src/features/Home/Footer.tsx
@@ -23,10 +23,10 @@ const Footer = () => {
       <div className="flex justify-between">
         <span className="text-sm text-white/80">chej098t@gmail.com</span>
         <div className="flex gap-4">
-          <Link href={GITHUB_REPO_LINK} target="_blank">
+          <Link href={GITHUB_REPO_LINK} target="_blank" aria-label="깃허브">
             <Github className="h-5 w-5 text-white/80 transition-all hover:text-white/60" />
           </Link>
-          <Link href={LINKEDIN_LINK} target="_blank">
+          <Link href={LINKEDIN_LINK} target="_blank" aria-label="링크드인">
             <Linkedin className="h-5 w-5 text-white/80 transition-all hover:text-white/60" />
           </Link>
         </div>

--- a/src/features/Home/Header.tsx
+++ b/src/features/Home/Header.tsx
@@ -18,7 +18,7 @@ const Header = () => {
         className="mb-10 w-[100px] md:w-[140px]"
         priority
         loading="eager"
-        alt="careerboost 이미지 로고"
+        alt="careerboost 로고"
       />
       <Image
         src="/text-logo.png"
@@ -32,7 +32,11 @@ const Header = () => {
       <p className="mb-14 text-center text-lg">
         이력서 작성과 동시에 AI 첨삭도 받아보세요
       </p>
-      <Button type="button" onClick={() => router.push(ROUTES.BASIC)}>
+      <Button
+        type="button"
+        aria-label="이력서 작성"
+        onClick={() => router.push(ROUTES.BASIC)}
+      >
         이력서 작성하기
       </Button>
     </header>


### PR DESCRIPTION
## ✨ 작업 내용
- [x] [react-hook-form `A11y` 향상](https://react-hook-form.com/advanced-usage#AccessibilityA11y)
   - [x] 폼 요소에 `aria-label`, `aria-required`, `aria-invalid`, `aria-checked`, `aria-errormessage` 추가
- [x] 폼 에러 메시지에 `role="alert"` 속성 추가: 입력한 값이 유효하지 않으면 screen reader가 해당 에러 메시지를 읽도록 함
- [x] 버튼 요소에 `aria-label` 속성 추가: screen reader가 기존에는 모든 버튼을 '버튼'으로만 읽는 문제 해결
- [x] MenuLink 컴포넌트 마크업 구조 리팩터링: 기존에는 글자 영역에 정확히 hover 했을 때 메뉴를 클릭할 수 있던 점을 해결
- [x] screen reader로 읽히지 않아도 되는 태그에는 `aria-hidden` 속성 추가

## 🖼️ 구현 스크린샷
### 접근성 향상 전
![image](https://github.com/dmswl98/careerboost/assets/76807107/6e550205-6cb8-4c20-aa91-7c3802fc160a)

### 접근성 향상 후
![image](https://github.com/dmswl98/careerboost/assets/76807107/172e6414-ef66-4762-8a73-4f1e3812aacf)

## 📌 참고 자료
[레진 WAI-ARIA 가이드라인](https://github.com/lezhin/accessibility/blob/master/aria/README.md#%EB%A0%88%EC%A7%84-wai-aria-%EA%B0%80%EC%9D%B4%EB%93%9C%EB%9D%BC%EC%9D%B8)