### PR TITLE
feat: PDF 이력서 스타일 수정

### DIFF
--- a/src/components/Pdf/PdfActivity.tsx
+++ b/src/components/Pdf/PdfActivity.tsx
@@ -1,4 +1,4 @@
-import { View } from '@react-pdf/renderer';
+import { Text, View } from '@react-pdf/renderer';
 
 import { MENU_INFO } from '@/constants/menu';
 import { type ActivitiesFormDataSchema } from '@/types/form';
@@ -18,14 +18,20 @@ const PdfActivity = ({ activities }: PdfActivityProps) => {
       {activities.map((activity) => (
         <View
           key={activity.id}
-          style={tailwind('border border-x-0 border-gray-200 py-6')}
+          style={tailwind(
+            'flex-row border border-x-0 border-gray-200 py-6 px-2'
+          )}
         >
-          <View style={tailwind('mb-4')}>
-            <PdfSectionInfo
-              title={activity.title}
-              date={{ start: activity.startDate, end: activity.endDate }}
-            />
-          </View>
+          <PdfSectionInfo
+            title={activity.title}
+            date={{ start: activity.startDate, end: activity.endDate }}
+          >
+            {activity.institution && (
+              <Text style={tailwind('text-sm font-semiBold')}>
+                {activity.institution}
+              </Text>
+            )}
+          </PdfSectionInfo>
           {activity.content && <PdfMarkdown content={activity.content} />}
         </View>
       ))}

--- a/src/components/Pdf/PdfDocument.tsx
+++ b/src/components/Pdf/PdfDocument.tsx
@@ -15,7 +15,7 @@ interface PdfDocumentProps {
 const PdfDocument = ({ resume }: PdfDocumentProps) => {
   return (
     <Document>
-      <Page size="A4" style={tailwind('font-regular px-8 pt-10 pb-14')} wrap>
+      <Page size="A4" style={tailwind('font-regular px-14 pt-14 pb-16')} wrap>
         <PdfUserInfo userInfo={resume.userInfo} />
         {resume.experiences.length > 0 && (
           <PdfExperience experiences={resume.experiences} />
@@ -28,10 +28,12 @@ const PdfDocument = ({ resume }: PdfDocumentProps) => {
         )}
         <Link
           src="https://github.com/dmswl98"
-          style={tailwind('absolute bottom-4 left-0 right-0 text-center')}
+          style={tailwind('absolute bottom-4 left-0 right-0 mt-10 text-center')}
           fixed
         >
-          <Text style={tailwind('text-gray-300 text-xs')}>@dmswl98</Text>
+          <Text style={tailwind('text-gray-300 text-xs')}>
+            Powered by careerBoost
+          </Text>
         </Link>
       </Page>
     </Document>

--- a/src/components/Pdf/PdfExperience.tsx
+++ b/src/components/Pdf/PdfExperience.tsx
@@ -1,4 +1,4 @@
-import { View } from '@react-pdf/renderer';
+import { Text, View } from '@react-pdf/renderer';
 
 import { MENU_INFO } from '@/constants/menu';
 import { type ExperienceFormDataSchema } from '@/types/form';
@@ -18,14 +18,19 @@ const PdfExperience = ({ experiences }: PdfExperienceProps) => {
       {experiences.map((experience) => (
         <View
           key={experience.id}
-          style={tailwind('border border-x-0 border-gray-200 py-6')}
+          style={tailwind(
+            'flex-row border border-x-0 border-gray-200 py-6 px-2'
+          )}
         >
-          <View style={tailwind('mb-4')}>
-            <PdfSectionInfo
-              title={experience.company}
-              date={{ start: experience.startDate, end: experience.endDate }}
-            />
-          </View>
+          <PdfSectionInfo
+            title={experience.company}
+            date={{ start: experience.startDate, end: experience.endDate }}
+          >
+            <View style={tailwind('text-sm font-semiBold leading-normal')}>
+              <Text>{experience.employmentType}</Text>
+              <Text>{experience.jobTitle}</Text>
+            </View>
+          </PdfSectionInfo>
           {experience.content && <PdfMarkdown content={experience.content} />}
         </View>
       ))}

--- a/src/components/Pdf/PdfLink.tsx
+++ b/src/components/Pdf/PdfLink.tsx
@@ -1,17 +1,22 @@
 /* eslint-disable jsx-a11y/alt-text */
-import { Image, Link, Text } from '@react-pdf/renderer';
+import { Link } from '@react-pdf/renderer';
 
 import { tailwind } from './config';
 
 interface PdfLinkProps {
+  label: string;
   url: string;
 }
 
-const PdfLink = ({ url }: PdfLinkProps) => {
+const PdfLink = ({ label, url }: PdfLinkProps) => {
   return (
-    <Link src={url} style={tailwind('flex-row items-center')}>
-      <Image style={tailwind('w-3 mr-2')} src={'/icons/link.png'} />
-      <Text style={tailwind('text-xs text-gray-500 mb-0.5')}>{url}</Text>
+    <Link
+      src={url}
+      style={tailwind(
+        'flex-row items-center text-sm text-gray-500 leading-relaxed'
+      )}
+    >
+      {label}
     </Link>
   );
 };

--- a/src/components/Pdf/PdfMarkdown.tsx
+++ b/src/components/Pdf/PdfMarkdown.tsx
@@ -18,24 +18,23 @@ const PdfMarkdown = ({ content }: PdfMarkdownProps) => {
 
 const markdownComponents: ComponentProps<typeof ReactMarkdown>['components'] = {
   h1: ({ children }) => (
-    <Text style={tailwind('font-bold text-[1.2rem] py-1')}>{children}</Text>
+    <Text style={tailwind('font-bold text-[1.1rem] py-1.5')}>{children}</Text>
   ),
   h2: ({ children }) => (
-    <Text style={tailwind('font-bold text-[1.1rem] py-1')}>{children}</Text>
+    <Text style={tailwind('font-bold text-[1rem] py-1.5')}>{children}</Text>
   ),
   h3: ({ children }) => (
-    <Text style={tailwind('font-bold text-base py-1')}>{children}</Text>
+    <Text style={tailwind('font-bold text-[0.9rem] py-1')}>{children}</Text>
   ),
   p: ({ children }) => <Text style={tailwind('text-sm py-1')}>{children}</Text>,
   ul: ({ children }) => (
-    <View style={tailwind('text-sm leading-relaxed')}>{children}</View>
+    <View style={tailwind('pb-2 text-sm leading-relaxed')}>{children}</View>
   ),
   li: ({ children }) => (
     <View
       style={tailwind('flex-row flex-nowrap text-sm py-px pr-3 leading-normal')}
     >
-      <Text style={tailwind('mr-1.5')}>•</Text>
-      <Text>{children}</Text>
+      <Text>• {children}</Text>
     </View>
   ),
   a: ({ children, href }) =>

--- a/src/components/Pdf/PdfMarkdown.tsx
+++ b/src/components/Pdf/PdfMarkdown.tsx
@@ -10,15 +10,30 @@ interface PdfMarkdownProps {
 
 const PdfMarkdown = ({ content }: PdfMarkdownProps) => {
   return (
-    <ReactMarkdown components={markdownComponents}>{content}</ReactMarkdown>
+    <View style={tailwind('flex-col w-full')}>
+      <ReactMarkdown components={markdownComponents}>{content}</ReactMarkdown>
+    </View>
   );
 };
 
 const markdownComponents: ComponentProps<typeof ReactMarkdown>['components'] = {
+  h1: ({ children }) => (
+    <Text style={tailwind('font-bold text-[1.2rem] py-1')}>{children}</Text>
+  ),
+  h2: ({ children }) => (
+    <Text style={tailwind('font-bold text-[1.1rem] py-1')}>{children}</Text>
+  ),
+  h3: ({ children }) => (
+    <Text style={tailwind('font-bold text-base py-1')}>{children}</Text>
+  ),
   p: ({ children }) => <Text style={tailwind('text-sm py-1')}>{children}</Text>,
-  ul: ({ children }) => <View style={tailwind('text-sm')}>{children}</View>,
+  ul: ({ children }) => (
+    <View style={tailwind('text-sm leading-relaxed')}>{children}</View>
+  ),
   li: ({ children }) => (
-    <View style={tailwind('flex-row text-sm py-0.5 pr-3')}>
+    <View
+      style={tailwind('flex-row flex-nowrap text-sm py-px pr-3 leading-normal')}
+    >
       <Text style={tailwind('mr-1.5')}>•</Text>
       <Text>{children}</Text>
     </View>
@@ -35,11 +50,7 @@ const markdownComponents: ComponentProps<typeof ReactMarkdown>['components'] = {
     <Text style={tailwind('text-sm font-bold')}>{children}</Text>
   ),
   code: ({ children }) => (
-    <Text style={tailwind('text-xs font-regular text-gray-500 bg-gray-100')}>
-      <Text style={tailwind('bg-gray-100')}> </Text>
-      {children}
-      <Text style={tailwind('bg-gray-100')}> </Text>
-    </Text>
+    <Text style={tailwind('font-light text-xs text-gray-700')}>{children}</Text>
   ),
 };
 

--- a/src/components/Pdf/PdfProject.tsx
+++ b/src/components/Pdf/PdfProject.tsx
@@ -20,15 +20,21 @@ const PdfProject = ({ projects }: PdfProjectProps) => {
       {projects.map((project) => (
         <View
           key={project.id}
-          style={tailwind('border border-x-0 border-gray-200 py-6')}
+          style={tailwind(
+            'flex-row border border-x-0 border-gray-200 py-6 px-2'
+          )}
         >
-          <View style={tailwind('mb-4')}>
-            <PdfSectionInfo
-              title={project.title}
-              date={{ start: project.startDate, end: project.endDate }}
-            />
-            {project.url && <PdfLink url={project.url} />}
-          </View>
+          <PdfSectionInfo
+            title={project.title}
+            date={{ start: project.startDate, end: project.endDate }}
+          >
+            {project.githubUrl && (
+              <PdfLink label="GitHub 링크" url={project.githubUrl} />
+            )}
+            {project.serviceUrl && (
+              <PdfLink label="배포 링크" url={project.serviceUrl} />
+            )}
+          </PdfSectionInfo>
           {project.content && <PdfMarkdown content={project.content} />}
         </View>
       ))}

--- a/src/components/Pdf/PdfSection.tsx
+++ b/src/components/Pdf/PdfSection.tsx
@@ -17,8 +17,8 @@ const PdfSection = ({
   title,
 }: StrictPropsWithChildren<PdfSectionProps>) => {
   return (
-    <View style={tailwind('my-8 text-gray-600')}>
-      <Text style={tailwind('mb-3 text-lg font-bold')}>{title}</Text>
+    <View style={tailwind('my-8 text-black')}>
+      <Text style={tailwind('mb-3 pr-24 text-lg font-bold')}>{title}</Text>
       {children}
     </View>
   );

--- a/src/components/Pdf/PdfSectionInfo.tsx
+++ b/src/components/Pdf/PdfSectionInfo.tsx
@@ -1,4 +1,5 @@
 import { Text, View } from '@react-pdf/renderer';
+import { type PropsWithChildren } from 'react';
 
 import { tailwind } from './config';
 
@@ -12,13 +13,18 @@ interface PdfSectionInfoProps {
   date: Date;
 }
 
-const PdfSectionInfo = ({ title, date }: PdfSectionInfoProps) => {
+const PdfSectionInfo = ({
+  children,
+  title,
+  date,
+}: PropsWithChildren<PdfSectionInfoProps>) => {
   return (
-    <View style={tailwind('flex-row items-center justify-between mb-2')}>
-      <Text style={tailwind('text-[11px] font-semiBold')}>{title}</Text>
-      <Text style={tailwind('text-xs mb-2')}>
+    <View style={tailwind('w-[200px] flex-col pr-6')}>
+      <Text style={tailwind('mb-1 text-lg font-semiBold')}>{title}</Text>
+      <Text style={tailwind('mb-3 text-xs')}>
         {date.start} ~ {date.end}
       </Text>
+      {children}
     </View>
   );
 };

--- a/src/components/Pdf/PdfUserInfo.tsx
+++ b/src/components/Pdf/PdfUserInfo.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable jsx-a11y/alt-text */
-import { Image, Link, Text, View } from '@react-pdf/renderer';
+import { Text, View } from '@react-pdf/renderer';
 
 import { type UserInfoFormDataSchema } from '@/types/form';
 
 import { tailwind } from './config';
+import PdfLink from './PdfLink';
 
 interface PdfUserInfoProps {
   userInfo: UserInfoFormDataSchema['userInfo'];
@@ -11,53 +12,28 @@ interface PdfUserInfoProps {
 
 const PdfUserInfo = ({ userInfo }: PdfUserInfoProps) => {
   return (
-    <View
-      style={tailwind(
-        'flex-col justify-between bg-gray-100 text-gray-600 p-8 mt-[-29px] mx-[-23px]'
+    <View style={tailwind('mb-6 text-black')}>
+      {userInfo.name && (
+        <Text style={tailwind('mr-4 mb-8 text-3xl font-bold leading-none')}>
+          {userInfo.name}
+        </Text>
       )}
-    >
-      <View style={tailwind('flex-row')}>
-        <Text style={tailwind('mr-4 text-2xl font-bold')}>
-          {userInfo.name || '이름'}
+      {userInfo.career && (
+        <Text style={tailwind('mb-4 text-lg font-semiBold leading-none')}>
+          {userInfo.career}
         </Text>
-        <Text style={tailwind('text-lg mt-1 font-semiBold')}>
-          {userInfo.career || '직무'}
-        </Text>
-      </View>
+      )}
+      <View style={tailwind('w-10 mb-4 border-b border-black')} />
       <View style={tailwind('flex-row gap-3 text-sm')}>
-        <View style={tailwind('flex-row items-center')}>
-          <Image style={tailwind('w-4 mr-2')} src={'/icons/phone.png'} />
-          <Text>{userInfo.phone || '전화번호'}</Text>
-        </View>
-        <View style={tailwind('flex-row items-center')}>
-          <Image style={tailwind('w-4 mr-2')} src={'/icons/mail.png'} />
-          <Text>{userInfo.email || '이메일'}</Text>
-        </View>
-        {userInfo.blog ? (
-          <Link src={userInfo.blog} style={tailwind('flex-row items-center')}>
-            <Image style={tailwind('w-4 mr-2')} src={'/icons/link.png'} />
-            <Text style={tailwind('text-gray-600')}>{userInfo.blog}</Text>
-          </Link>
-        ) : (
-          <View style={tailwind('flex-row items-center')}>
-            <Image style={tailwind('w-4 mr-2')} src={'/icons/link.png'} />
-            <Text style={tailwind('text-gray-600')}>블로그</Text>
-          </View>
-        )}
-        {userInfo.github ? (
-          <Link src={userInfo.github} style={tailwind('flex-row items-center')}>
-            <Image style={tailwind('w-4 mr-2')} src={'/icons/github.png'} />
-            <Text style={tailwind('text-gray-600')}>{userInfo.github}</Text>
-          </Link>
-        ) : (
-          <View style={tailwind('flex-row items-center')}>
-            <Image style={tailwind('w-4 mr-2')} src={'/icons/github.png'} />
-            <Text style={tailwind('text-gray-600')}>깃허브</Text>
-          </View>
-        )}
+        {userInfo.phone && <Text>{userInfo.phone}</Text>}
+        {userInfo.email && <Text>{userInfo.email}</Text>}
+        {userInfo.blog && <PdfLink label="Blog" url={userInfo.blog} />}
+        {userInfo.github && <PdfLink label="GitHub" url={userInfo.github} />}
       </View>
       {userInfo.brief && (
-        <Text style={tailwind('text-sm mt-4')}>{userInfo.brief}</Text>
+        <Text style={tailwind('mt-3 text-sm leading-normal')}>
+          {userInfo.brief}
+        </Text>
       )}
     </View>
   );

--- a/src/components/Pdf/config.ts
+++ b/src/components/Pdf/config.ts
@@ -3,7 +3,7 @@ import { createTw } from 'react-pdf-tailwind';
 
 const Pretendard = {
   light:
-    'https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-ExtraLight.ttf',
+    'https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-Light.ttf',
   regular:
     'https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-Regular.ttf',
   semiBold:

--- a/src/features/Project/ProjectFormView.tsx
+++ b/src/features/Project/ProjectFormView.tsx
@@ -145,14 +145,26 @@ const ProjectFormView = ({ dictionary }: ProjectFormViewProps) => {
                 }}
               />
               <Input
-                {...register(`projects.${index}.url`)}
+                {...register(`projects.${index}.githubUrl`)}
                 id={`url-${index}`}
                 className="mb-3"
-                label={{ text: dictionary.project.label.url }}
+                label={{ text: dictionary.project.label.githubUrl }}
                 placeholder={dictionary.project.placeholder.url}
-                error={errors.projects?.[index]?.url?.message}
+                error={errors.projects?.[index]?.githubUrl?.message}
                 onChange={(e) => {
-                  register(`projects.${index}.url`).onChange(e);
+                  register(`projects.${index}.githubUrl`).onChange(e);
+                  handleAutoSave();
+                }}
+              />
+              <Input
+                {...register(`projects.${index}.serviceUrl`)}
+                id={`url-${index}`}
+                className="mb-3"
+                label={{ text: dictionary.project.label.serviceUrl }}
+                placeholder={dictionary.project.placeholder.url}
+                error={errors.projects?.[index]?.serviceUrl?.message}
+                onChange={(e) => {
+                  register(`projects.${index}.serviceUrl`).onChange(e);
                   handleAutoSave();
                 }}
               />

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -24,7 +24,7 @@
       "phone": "Phone",
       "email": "Email",
       "blog": "Blog",
-      "github": "Github",
+      "github": "GitHub",
       "brief": "Brief Introduction"
     },
     "placeholder": {
@@ -62,7 +62,8 @@
     },
     "label": {
       "title": "Project Name",
-      "url": "Project URL",
+      "githubUrl": "Project URL",
+      "serviceUrl": "Service URL",
       "content": "Project Content",
       "period": "Still participating"
     },

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -62,7 +62,8 @@
     },
     "label": {
       "title": "프로젝트명",
-      "url": "프로젝트 주소",
+      "githubUrl": "프로젝트 주소",
+      "serviceUrl": "서비스 배포 주소",
       "content": "프로젝트 내용",
       "period": "아직 진행 중이에요"
     },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -20,6 +20,25 @@ a {
   text-decoration: none;
 }
 
+.markdown h1,
+.markdown h2,
+.markdown h3 {
+  font-weight: 600;
+  line-height: 2;
+}
+
+.markdown h1 {
+  font-size: 1.2rem;
+}
+
+.markdown h2 {
+  font-size: 1.1rem;
+}
+
+.markdown h3 {
+  font-size: 1rem;
+}
+
 .markdown ul,
 .markdown ol {
   margin-left: 1.4rem;

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -48,7 +48,10 @@ export const resumeFormSchema = z.object({
         .regex(DATE_REGEX, { message: UNFORMATTED_DATA })
         .or(z.literal(PLACEHOLDER.PERIOD.PROGRESS)),
       content: z.string().min(50, { message: '50자 이상 작성해주세요' }),
-      url: z
+      githubUrl: z
+        .optional(z.string().url({ message: UNFORMATTED_DATA }))
+        .or(z.literal('')),
+      serviceUrl: z
         .optional(z.string().url({ message: UNFORMATTED_DATA }))
         .or(z.literal('')),
     })


### PR DESCRIPTION
## ✨ 작업 내용
- [x] PDF 이력서 레이아웃, 스타일 수정
- [x] PDF [heading 태그 마크다운 문법 지원](https://github.com/dmswl98/careerboost/commit/4d7a5d5b3aa384501210c540e50d5ecdfbdc8683)
- [x] 프로젝트 폼에 '서비스 배포 링크' 인풋 추가

## 📁 PDF 이력서 예시
### PDF 이력서 예시 파일 보기
[최은지님의_이력서.pdf](https://github.com/dmswl98/careerboost/files/12927172/_.pdf)


![최은지님의_이력서_pages-to-jpg-0001](https://github.com/dmswl98/careerboost/assets/76807107/441f16e6-eff5-4afa-9257-3b19b4c6d33f)
![최은지님의_이력서_pages-to-jpg-0002](https://github.com/dmswl98/careerboost/assets/76807107/cb6d2178-d7bc-48fd-b7fb-e10100d5fbae)

